### PR TITLE
Reolves Issue #32: Updated "next variation" algorithm to properly select next index

### DIFF
--- a/src/main/java/info/jbcs/minecraft/chisel/ChiselLeftClick.java
+++ b/src/main/java/info/jbcs/minecraft/chisel/ChiselLeftClick.java
@@ -73,12 +73,29 @@ public class ChiselLeftClick
             if(variations == null || variations.length < 2) return; //noReplace = true;
             else
             {
-                int index = blockMeta + 1;
-                while(variations[index].block.equals(block) && variations[index].damage == blockMeta)
+                int index = -1;
+                //Find the index of the next block in the variation list
+                for (int i = 0; i < variations.length; ++i)
                 {
-                    index++;
-                    if(index >= variations.length) index = 0;
+                    CarvingVariation currVariation = variations[i];
+                    
+                    //If the metadata matches, then we are interested in the block AFTER this one
+                    if (currVariation.block.equals(block) && currVariation.meta == blockMeta)
+                    {
+                        index = i + 1;
+                    }
                 }
+                //If no index was found, something is wrong. Return.
+                if (index < 0)
+                {
+                    return;
+                }
+                //If the the current block is the last in the list, loop back to the first
+                else if (index >= variations.length)
+                {
+                    index = 0;
+                }
+                
                 CarvingVariation var = variations[index];
                 chiselTarget = new ItemStack(var.block, 1, var.damage);
             }


### PR DESCRIPTION
Updated "next variation" algorithm to properly select next index instead of relying on incrementing metadata value.

The commit didn't diff correctly, but lines 76-81 were removed from the old file and replaced with lines 76-97 in the new file. The modified algorithm has been tested in the test world and works properly for all tested blocks. This also fixes an unreported bug that causes left-clicking on stairs to not cycle properly due to the strange way that block IDs and metadata values are currently assigned by the stairs maker.

The only block that I found that the new algorithm did not work correctly for was ice stairs, as it would not cycle back to the original stairs. However, this problem was already existing. (I'll look into it later if I have time.)
