### PR TITLE
Added the tool required to break road lines (Fixes #78)

### DIFF
--- a/src/main/java/com/cricketcraft/chisel/block/BlockRoadLine.java
+++ b/src/main/java/com/cricketcraft/chisel/block/BlockRoadLine.java
@@ -9,6 +9,7 @@ import net.minecraft.util.IIcon;
 import net.minecraft.world.World;
 
 import com.cricketcraft.chisel.client.render.BlockRoadLineRenderer;
+import com.cricketcraft.chisel.config.Configurations;
 
 public class BlockRoadLine extends Block {
 
@@ -19,7 +20,9 @@ public class BlockRoadLine extends Block {
 	public BlockRoadLine() {
 		super(Material.circuits);
 
-		this.setHarvestLevel("pickaxe",0);
+		if (Configurations.useRoadLineTool) {
+			this.setHarvestLevel(Configurations.getRoadLineTool,roadLineToolLevel);
+		}
 		this.setBlockBounds(0.0f, 0.0f, 0.0f, 1.0f, 0.00390625f, 1.0f);
 		// this.setBlockBounds(0.0F, 0.0F, 0.0F, 1.0F, 0.0625F, 1.0F);
 	}

--- a/src/main/java/com/cricketcraft/chisel/block/BlockRoadLine.java
+++ b/src/main/java/com/cricketcraft/chisel/block/BlockRoadLine.java
@@ -19,6 +19,7 @@ public class BlockRoadLine extends Block {
 	public BlockRoadLine() {
 		super(Material.circuits);
 
+		this.setHarvestLevel("pickaxe",0);
 		this.setBlockBounds(0.0f, 0.0f, 0.0f, 1.0f, 0.00390625f, 1.0f);
 		// this.setBlockBounds(0.0F, 0.0F, 0.0F, 1.0F, 0.0625F, 1.0F);
 	}

--- a/src/main/java/com/cricketcraft/chisel/config/Configurations.java
+++ b/src/main/java/com/cricketcraft/chisel/config/Configurations.java
@@ -39,6 +39,10 @@ public class Configurations {
 	public static int diamondChiselMaxDamage;
 	public static boolean ironChiselCanLeftClick;
 	
+	public static boolean useRoadLineTool;
+	public static String getRoadLineTool;
+	public static int roadLineToolLevel;
+	
 	public static boolean refreshConfig() {
 
 		String category;
@@ -78,6 +82,12 @@ public class Configurations {
 		ironChiselMaxDamage = config.get(category, "ironChiselMaxDamage", 500, "The max damage of the standard iron chisel. Default: 500.").getInt();
 		diamondChiselMaxDamage = config.get(category, "diamondChiselMaxDamage", 5000, "The max damage of the diamond chisel. Default: 5000").getInt();
 		ironChiselCanLeftClick = config.get(category, "ironChiselCanLeftClick", true, "If this is true, the iron chisel can left click chisel blocks. If false, it cannot.").getBoolean();
+		
+		/* block */
+		category = "block";
+		useRoadLineTool = config.get(category, "useRoadLineTool", false, "Should the road line require a tool to break (If false, road lines can be broken in Adventure)").getBoolean();
+		getRoadLineTool = config.get(category, "getRoadLineTool","pickaxe","The tool that is able to break roadLines (requires useRoadLineTool to be true to take effect)").getString();
+		roadLineToolLevel = config.get(category, "roadLineToolLevel",0,"The lowest harvest level of the tool able to break the road lines (requires useRoadLineTool to be true to take effect) (0 = Wood/Gold, 1 = Stone, 2 = Iron, 3 = Diamond) Default: 0").getInt();
 		
 		if (config.hasChanged()) {
 			config.save();


### PR DESCRIPTION
Set it as a wood pickaxe. Still breaks instantly, but it cannot be broken in Adventure Mode. Can be configured to any tool you desire (except shears, in which case, just make it implement IShearable and get rid of the setHarvestLevel line).

This should allow maps to keep players from exploiting the old way.