### PR TITLE
Fix #128 Ignore clicks on active chisel while it's GUI is open

### DIFF
--- a/src/main/java/com/cricketcraft/chisel/inventory/ContainerChisel.java
+++ b/src/main/java/com/cricketcraft/chisel/inventory/ContainerChisel.java
@@ -19,6 +19,7 @@ public class ContainerChisel extends Container {
 	public ItemStack chisel;
 	public boolean finished;
 	public Carving carving;
+	private Slot activeChiselSlot;
 
 	public ContainerChisel(InventoryPlayer inventoryplayer, InventoryChiselSelection inv) {
 		inventory = inv;
@@ -45,7 +46,11 @@ public class ContainerChisel extends Container {
 
 		top += 58;
 		for (int i = 0; i < 9; i++) {
-			addSlotToContainer(new Slot(inventoryplayer, i, left + ((i % 9) * 18), top + (i / 9) * 18));
+			Slot slot = new Slot(inventoryplayer, i, left + ((i % 9) * 18), top + (i / 9) * 18);
+			if (i == currentIndex) {
+				activeChiselSlot = slot;
+			}
+			addSlotToContainer(slot);
 		}
 
 		chisel = inventoryplayer.getCurrentItem();
@@ -64,6 +69,14 @@ public class ContainerChisel extends Container {
 	public ItemStack slotClick(int par1, int par2, int par3, EntityPlayer par4EntityPlayer) {
 		if (par3 == 2 && par2 == currentIndex)
 			return null;
+
+		// if the slot containing the active chisel was clicked, ignore the click
+		if (par1 >= 0 && activeChiselSlot != null) {
+			Slot slot = (Slot) this.inventorySlots.get(par1);
+			if (slot == activeChiselSlot) {
+				return null;
+			}
+		}
 
 		return super.slotClick(par1, par2, par3, par4EntityPlayer);
 	}


### PR DESCRIPTION
If the user clicks on the slot containing the active chisel, the click will now be ignored. This prevents the container slots getting into an unexpected state.

I can't help the feeling I've missed a simple code path somewhere to directly compare the instance of the slot contents?