### PR TITLE
change V4 and V9 textures to tiling instead of staircasing

### DIFF
--- a/src/main/java/com/cricketcraft/chisel/carving/CarvableHelper.java
+++ b/src/main/java/com/cricketcraft/chisel/carving/CarvableHelper.java
@@ -255,19 +255,40 @@ public class CarvableHelper {
 			else if (n)
 				return variation.seamsCtmVert.icons[reverse ? 3 : 2];
 			return variation.seamsCtmVert.icons[0];
-		case V9:
-		case V4:
-			int index = x + y + z;
-            if ((side==2)||(side==5))
-            {
-                index=-index;
-            }
-			while (index < 0)
-            {
-                index = index+10000;
+        case V9:
+        case V4:
+            int variationSize = (variation.kind == V9) ? 3 : 2;
+
+            int xModulus = x % variationSize;
+            int zModulus = z % variationSize;
+            //This ensures that blocks placed near 0,0 or it's axis' do not misbehave
+            int textureX = (xModulus < 0) ? (xModulus + variationSize) : xModulus;
+            int textureZ = (zModulus < 0) ? (zModulus + variationSize) : zModulus;
+            //Always invert the y index
+            int textureY = (variationSize - (y % variationSize) - 1);
+
+            if (side == 2 || side == 5) {
+                //For WEST, SOUTH reverse the indexes for both X and Z
+                textureX = (variationSize - textureX - 1);
+                textureZ = (variationSize - textureZ - 1);
+            } else if (side == 0) {
+                //For DOWN, reverse the indexes for only Z
+                textureZ = (variationSize - textureZ - 1);
             }
 
-			return variation.variations9.icons[index % ((variation.kind == V9) ? 9 : 4)];
+            int index;
+            if (side == 0 || side == 1) {
+                // DOWN || UP
+                index = textureX + textureZ * variationSize;
+            } else if (side == 2 || side == 3) {
+                // NORTH || SOUTH
+                index = textureX + textureY * variationSize;
+            } else {
+                // WEST || EAST
+                index = textureZ + textureY * variationSize;
+            }
+
+            return variation.variations9.icons[index];
 		case CTMX:
 			return variation.icon;
         case R16:


### PR DESCRIPTION
Drullkus was trying out some fancy 2x2 brick patterns for a texture called "stonebrick2" that didn't quite play nice. I've made some adjustments to the way v4 and v9 variation icons are selected to make them tile nicely instead of having a diagonal pattern.

This does have a flow on effect to other blocks, such as the factory/plating which doesn't look bad with the change, on the other hand the Cracked Temple Plate looks obviously tiled and I have concerns that might not look as nice. It might be worthwhile changing that to a r9 instead of a v9. I can provide visual comparisons if you'd like.