### PR TITLE
Backwards Connected Texture Fix (Issue #190)

### DIFF
--- a/src/main/java/com/cricketcraft/chisel/carving/CarvableHelper.java
+++ b/src/main/java/com/cricketcraft/chisel/carving/CarvableHelper.java
@@ -254,7 +254,7 @@ public class CarvableHelper {
 
 			boolean p;
 			boolean n;
-			boolean reverse = side == 2 || side == 4;
+			boolean reverse = side == 2 || side == 5;
 
 			if (side < 4) {
 				p = CTM.isConnected(world, x - 1, y, z, side, block, metadata);


### PR DESCRIPTION
The wrong directions are used for reversing textures. As a result, some
textures for the laboratory blocks appeared incorrect. This will fix
issue 190. A single digit change fixes both directions, as direction 4
did not need to be reversed, but was, and direction 5 needed to be
reversed, but wasn't.